### PR TITLE
Initial support for Ethereum as a coin type.

### DIFF
--- a/messages.proto
+++ b/messages.proto
@@ -290,7 +290,7 @@ message GetAddress {
  * @prev GetAddress
  */
 message Address {
-	required string address = 1;		// Coin address in Base58 encoding
+	required string address = 1;		// Coin address in compact human-readable form
 }
 
 /**

--- a/types.proto
+++ b/types.proto
@@ -135,6 +135,11 @@ message HDNodePathType {
 	repeated uint32 address_n = 2;						// BIP-32 path to derive the key from node
 }
 
+enum NetworkType {
+	BITCOIN = 0;  // Bitcoin and derivatives
+	ETHEREUM = 1; // Ethereum and derivatives
+}
+
 /**
  * Structure representing Coin
  * @used_in Features
@@ -145,6 +150,7 @@ message CoinType {
 	optional uint32 address_type = 3 [default=0];
 	optional uint64 maxfee_kb = 4;
 	optional uint32 address_type_p2sh = 5 [default=5];
+	optional NetworkType network_type = 6 [default=BITCOIN];
 }
 
 /**


### PR DESCRIPTION
Defines a new field on the CoinType proto, network_type, and a corresponding enum, which allows discriminating Bitcoin-derived networks from Ethereum-derived networks.

I'm submitting this as a separate PR on the theory that you might prefer small, easily reviewed PRs; if you'd prefer one large PR with complete Ethereum support instead, please let me know.
