### PR TITLE
feat: Solana Ed25519 protocol messages

### DIFF
--- a/messages-solana.proto
+++ b/messages-solana.proto
@@ -1,0 +1,71 @@
+/*
+ * Messages (Solana specific) for KeepKey Communication
+ *
+ * Solana address derivation, transaction signing, and message signing
+ * via Ed25519 on the device.
+ */
+
+syntax = "proto2";
+
+// Sugar for easier handling in Java
+option java_package = "com.keepkey.deviceprotocol";
+option java_outer_classname = "KeepKeyMessageSolana";
+
+/**
+ * Request: Ask device for Solana address corresponding to address_n path
+ * @next SolanaAddress
+ * @next Failure
+ */
+message SolanaGetAddress {
+    repeated uint32 address_n = 1;          // BIP-32/BIP-44 path (e.g. m/44'/501'/0'/0')
+    optional string coin_name = 2 [default = "Solana"];
+    optional bool show_display = 3;         // optionally show on display before sending the result
+}
+
+/**
+ * Response: Contains Solana address (Base58-encoded Ed25519 public key)
+ * @prev SolanaGetAddress
+ */
+message SolanaAddress {
+    optional string address = 1;            // Base58-encoded Solana address
+}
+
+/**
+ * Request: Ask device to sign a raw Solana transaction
+ * @next SolanaSignedTx
+ * @next Failure
+ */
+message SolanaSignTx {
+    repeated uint32 address_n = 1;          // BIP-32/BIP-44 path to signing key
+    optional string coin_name = 2 [default = "Solana"];
+    optional bytes raw_tx = 3;              // Serialized Solana transaction bytes
+}
+
+/**
+ * Response: Contains Ed25519 signature of the transaction
+ * @prev SolanaSignTx
+ */
+message SolanaSignedTx {
+    optional bytes signature = 1;           // 64-byte Ed25519 signature
+}
+
+/**
+ * Request: Ask device to sign an arbitrary message with Ed25519
+ * @next SolanaMessageSignature
+ * @next Failure
+ */
+message SolanaSignMessage {
+    repeated uint32 address_n = 1;          // BIP-32/BIP-44 path to signing key
+    optional string coin_name = 2 [default = "Solana"];
+    optional bytes message = 3;             // Arbitrary message bytes to sign
+    optional bool show_display = 4;         // Show message on device display
+}
+
+/**
+ * Response: Contains Ed25519 signature and public key for the signed message
+ * @prev SolanaSignMessage
+ */
+message SolanaMessageSignature {
+    optional bytes public_key = 1;          // 32-byte Ed25519 public key
+    optional bytes signature = 2;           // 64-byte Ed25519 signature
+}

--- a/messages.proto
+++ b/messages.proto
@@ -125,6 +125,14 @@ enum MessageType {
   MessageType_NanoSignTx = 702 [ (wire_in) = true ];
   MessageType_NanoSignedTx = 703 [ (wire_out) = true ];
 
+  // Solana
+  MessageType_SolanaGetAddress = 750 [ (wire_in) = true ];
+  MessageType_SolanaAddress = 751 [ (wire_out) = true ];
+  MessageType_SolanaSignTx = 752 [ (wire_in) = true ];
+  MessageType_SolanaSignedTx = 753 [ (wire_out) = true ];
+  MessageType_SolanaSignMessage = 754 [ (wire_in) = true ];
+  MessageType_SolanaMessageSignature = 755 [ (wire_out) = true ];
+
   // Binance
   MessageType_BinanceGetAddress = 800 [ (wire_in) = true ];
   MessageType_BinanceAddress = 801 [ (wire_out) = true ];


### PR DESCRIPTION
## Summary
- Add `messages-solana.proto` with Solana address derivation, transaction signing, and message signing messages
- Add 6 Solana `MessageType` enum entries (750–755) to `messages.proto`

## Message Types
| ID | Name | Direction |
|----|------|-----------|
| 750 | `SolanaGetAddress` | wire_in |
| 751 | `SolanaAddress` | wire_out |
| 752 | `SolanaSignTx` | wire_in |
| 753 | `SolanaSignedTx` | wire_out |
| 754 | `SolanaSignMessage` | wire_in |
| 755 | `SolanaMessageSignature` | wire_out |

## Context
These message types are already implemented in firmware (7.11.0) but the proto definitions were missing from this repo. hdwallet currently uses hand-rolled protobuf shims with hardcoded field numbers — this PR adds the canonical definitions so generated code can replace the shims.

## Test plan
- [ ] Protobuf compiles cleanly
- [ ] Field numbers match firmware implementation (750–755)
- [ ] hdwallet can build against generated `messages-solana_pb` types