### PR TITLE
feat: add TRON protocol messages

### DIFF
--- a/messages-tron.options
+++ b/messages-tron.options
@@ -1,0 +1,11 @@
+TronGetAddress.address_n max_count:8
+TronGetAddress.coin_name max_size:21
+TronSignTx.address_n max_count:8
+TronSignTx.coin_name max_size:21
+TronSignTx.raw_data max_size:1024
+TronSignTx.ref_block_bytes max_size:2
+TronSignTx.ref_block_hash max_size:8
+TronSignTx.contract_type max_size:50
+TronSignTx.to_address max_size:35
+TronAddress.address max_size:35
+TronSignedTx.signature max_size:65

--- a/messages-tron.proto
+++ b/messages-tron.proto
@@ -1,0 +1,55 @@
+/*
+ * Messages (TRON specific) for KeepKey Communication
+ *
+ */
+
+syntax = "proto2";
+
+// Sugar for easier handling in Java
+option java_package = "com.keepkey.deviceprotocol";
+option java_outer_classname = "KeepKeyMessageTron";
+
+/**
+ * Request: Ask device for TRON address corresponding to address_n path
+ * @next PassphraseRequest
+ * @next TronAddress
+ * @next Failure
+ */
+message TronGetAddress {
+    repeated uint32 address_n = 1;                // BIP-32 path to derive the key from master node
+    optional string coin_name = 2 [default='Tron'];
+    optional bool show_display = 3;               // optionally show on display before sending the result
+}
+
+/**
+ * Response: Contains a TRON address derived from device private seed
+ * @prev TronGetAddress
+ */
+message TronAddress {
+    optional string address = 1;                  // TRON address in Base58Check encoding
+}
+
+/**
+ * Request: ask device to sign TRON transaction
+ * @start
+ * @next TronSignedTx
+ */
+message TronSignTx {
+    repeated uint32 address_n = 1;                // BIP-32 path to derive the key from master node
+    optional string coin_name = 2 [default='Tron'];
+    optional bytes raw_data = 3;                  // Raw transaction data (serialized by client)
+    optional bytes ref_block_bytes = 4;           // Reference block bytes
+    optional bytes ref_block_hash = 5;            // Reference block hash
+    optional uint64 expiration = 6;               // Transaction expiration timestamp
+    optional string contract_type = 7;            // Contract type (e.g., "TransferContract")
+    optional string to_address = 8;               // Destination address (for display)
+    optional uint64 amount = 9;                   // Transfer amount in SUN (for display)
+}
+
+/**
+ * Response: signature for transaction
+ * @end
+ */
+message TronSignedTx {
+    optional bytes signature = 1;                 // ECDSA signature (65 bytes: r + s + recovery_id)
+}

--- a/messages.proto
+++ b/messages.proto
@@ -190,6 +190,12 @@ enum MessageType {
   MessageType_MayachainMsgRequest = 1203 [ (wire_out) = true ];
   MessageType_MayachainMsgAck = 1204 [ (wire_in) = true ];
   MessageType_MayachainSignedTx = 1205 [ (wire_out) = true ];
+
+  // TRON
+  MessageType_TronGetAddress = 1400 [ (wire_in) = true ];
+  MessageType_TronAddress = 1401 [ (wire_out) = true ];
+  MessageType_TronSignTx = 1402 [ (wire_in) = true ];
+  MessageType_TronSignedTx = 1403 [ (wire_out) = true ];
 }
 
 ////////////////////


### PR DESCRIPTION
## Summary
- Add TRON message definitions (wire IDs 1300-1303): TronGetAddress, TronAddress, TronSignTx, TronSignedTx
- SLIP-44 coin type 195, secp256k1 curve, Base58Check addresses (T-prefix)
- Includes nanopb size constraints in messages-tron.options

## Protocol Details
- **TronGetAddress** (1300): Derives address from BIP-32 path `m/44'/195'/0'/0/0`
- **TronAddress** (1301): Returns Base58Check-encoded address (max 35 chars)
- **TronSignTx** (1302): Signs protobuf-encoded raw transaction data (max 1024 bytes)
- **TronSignedTx** (1303): Returns 65-byte ECDSA signature (r + s + recovery_id)

## Files Changed
- `messages.proto` — Register wire IDs in MessageType enum
- `messages-tron.proto` — Message definitions
- `messages-tron.options` — nanopb field size constraints

## Test plan
- [ ] Verify protobuf compilation with `protoc`
- [ ] Validate wire ID range doesn't conflict with existing messages
- [ ] Integration test with firmware implementation