### PR TITLE
feat: add TON protocol messages (SLIP-44 607)

### DIFF
--- a/messages-ton.options
+++ b/messages-ton.options
@@ -1,0 +1,9 @@
+TonGetAddress.address_n max_count:8
+TonGetAddress.coin_name max_size:21
+TonSignTx.address_n max_count:8
+TonSignTx.coin_name max_size:21
+TonSignTx.raw_tx max_size:1024
+TonSignTx.to_address max_size:50
+TonAddress.address max_size:50
+TonAddress.raw_address max_size:70
+TonSignedTx.signature max_size:64

--- a/messages-ton.proto
+++ b/messages-ton.proto
@@ -1,0 +1,58 @@
+/*
+ * Messages (TON specific) for KeepKey Communication
+ *
+ */
+
+syntax = "proto2";
+
+// Sugar for easier handling in Java
+option java_package = "com.keepkey.deviceprotocol";
+option java_outer_classname = "KeepKeyMessageTon";
+
+/**
+ * Request: Ask device for TON address corresponding to address_n path
+ * @next PassphraseRequest
+ * @next TonAddress
+ * @next Failure
+ */
+message TonGetAddress {
+    repeated uint32 address_n = 1;                // BIP-32 path to derive the key from master node
+    optional string coin_name = 2 [default='Ton'];
+    optional bool show_display = 3;               // optionally show on display before sending the result
+    optional bool bounceable = 4 [default=true];  // bounceable flag for address encoding
+    optional bool testnet = 5 [default=false];    // testnet flag for address encoding
+    optional sint32 workchain = 6 [default=0];    // workchain ID (-1 or 0)
+}
+
+/**
+ * Response: Contains a TON address derived from device private seed
+ * @prev TonGetAddress
+ */
+message TonAddress {
+    optional string address = 1;                  // TON address in user-friendly Base64 encoding
+    optional string raw_address = 2;              // TON address in raw format (workchain:hash)
+}
+
+/**
+ * Request: ask device to sign TON transaction
+ * @start
+ * @next TonSignedTx
+ */
+message TonSignTx {
+    repeated uint32 address_n = 1;                // BIP-32 path to derive the key from master node
+    optional string coin_name = 2 [default='Ton'];
+    optional bytes raw_tx = 3;                    // Raw transaction data (serialized by client)
+    optional uint32 expire_at = 4;                // Transaction expiration timestamp
+    optional uint32 seqno = 5;                    // Wallet sequence number
+    optional sint32 workchain = 6 [default=0];    // Workchain ID (-1 or 0)
+    optional string to_address = 7;               // Destination address (for display)
+    optional uint64 amount = 8;                   // Transfer amount in nanoTON (for display)
+}
+
+/**
+ * Response: signature for transaction
+ * @end
+ */
+message TonSignedTx {
+    optional bytes signature = 1;                 // Ed25519 signature (64 bytes)
+}

--- a/messages.proto
+++ b/messages.proto
@@ -190,6 +190,12 @@ enum MessageType {
   MessageType_MayachainMsgRequest = 1203 [ (wire_out) = true ];
   MessageType_MayachainMsgAck = 1204 [ (wire_in) = true ];
   MessageType_MayachainSignedTx = 1205 [ (wire_out) = true ];
+
+  // TON
+  MessageType_TonGetAddress = 1500 [ (wire_in) = true ];
+  MessageType_TonAddress = 1501 [ (wire_out) = true ];
+  MessageType_TonSignTx = 1502 [ (wire_in) = true ];
+  MessageType_TonSignedTx = 1503 [ (wire_out) = true ];
 }
 
 ////////////////////


### PR DESCRIPTION
## Summary
- Add TON (The Open Network) protocol buffer definitions for KeepKey device communication
- Message types: TonGetAddress (1400), TonAddress (1401), TonSignTx (1402), TonSignedTx (1403)
- Ed25519 curve, BIP-44 path m/44'/607'/0', supports bounceable/testnet/workchain address options

## Files
- `messages-ton.proto` — message definitions (GetAddress, Address, SignTx, SignedTx)
- `messages-ton.options` — field size constraints for firmware
- `messages.proto` — MessageType enum entries (1400-1403)

## Test plan
- [ ] Verify proto syntax with `protoc --lint_out=. messages-ton.proto`
- [ ] Confirm no duplicate MessageType IDs
- [ ] Validate against firmware TON implementation