### PR TITLE
feat: Zcash Orchard, TON clear-signing, EVM metadata, BIP-85 contract update

### DIFF
--- a/messages-ethereum.options
+++ b/messages-ethereum.options
@@ -1,0 +1,2 @@
+EthereumTxMetadata.signed_payload max_size:1024
+EthereumMetadataAck.display_summary max_size:32

--- a/messages-ethereum.proto
+++ b/messages-ethereum.proto
@@ -87,6 +87,32 @@ message EthereumTxAck {
 	optional bytes data_chunk = 1;			// Bytes from transaction payload (<= 1024 bytes)
 }
 
+///////////////////////////////////////////
+// Ethereum: Clear signing metadata     //
+///////////////////////////////////////////
+
+/**
+ * Request: Send signed metadata before EthereumSignTx for clear signing.
+ * Host sends this BEFORE EthereumSignTx when metadata is available.
+ * If not sent, existing signing flow is unchanged (backwards compatible).
+ * @next EthereumMetadataAck
+ * @next Failure
+ */
+message EthereumTxMetadata {
+	optional bytes signed_payload = 1;		// Canonical signed metadata blob
+	optional uint32 metadata_version = 2;		// Schema version (defaults to 1)
+	optional uint32 key_id = 3;			// Embedded verification key slot (0-3)
+}
+
+/**
+ * Response: Result of metadata verification.
+ * @prev EthereumTxMetadata
+ */
+message EthereumMetadataAck {
+	required uint32 classification = 1;		// 0=OPAQUE, 1=VERIFIED, 2=MALFORMED
+	optional string display_summary = 2;		// Brief result for host logging
+}
+
 ////////////////////////////////////////
 // Ethereum: Message signing messages //
 ////////////////////////////////////////

--- a/messages-solana.options
+++ b/messages-solana.options
@@ -1,0 +1,15 @@
+SolanaGetAddress.address_n max_count:8
+SolanaGetAddress.coin_name max_size:21
+SolanaSignTx.address_n max_count:8
+SolanaSignTx.coin_name max_size:21
+SolanaSignTx.raw_tx max_size:1232
+SolanaSignTx.token_info max_count:4
+SolanaTokenInfo.mint max_size:32
+SolanaTokenInfo.symbol max_size:13
+SolanaAddress.address max_size:45
+SolanaSignedTx.signature max_size:64
+SolanaSignMessage.address_n max_count:8
+SolanaSignMessage.coin_name max_size:21
+SolanaSignMessage.message max_size:1024
+SolanaMessageSignature.public_key max_size:32
+SolanaMessageSignature.signature max_size:64

--- a/messages-solana.proto
+++ b/messages-solana.proto
@@ -31,6 +31,15 @@ message SolanaAddress {
 }
 
 /**
+ * Host-provided token metadata for SPL token display
+ */
+message SolanaTokenInfo {
+    optional bytes mint = 1;                // 32-byte mint public key
+    optional string symbol = 2;            // Token symbol e.g. "USDC" (max 12)
+    optional uint32 decimals = 3;          // Token decimals e.g. 6
+}
+
+/**
  * Request: Ask device to sign a raw Solana transaction
  * @next SolanaSignedTx
  * @next Failure
@@ -39,6 +48,7 @@ message SolanaSignTx {
     repeated uint32 address_n = 1;          // BIP-32/BIP-44 path to signing key
     optional string coin_name = 2 [default = "Solana"];
     optional bytes raw_tx = 3;              // Serialized Solana transaction bytes
+    repeated SolanaTokenInfo token_info = 4; // Token metadata for display (max 4)
 }
 
 /**

--- a/messages-ton.options
+++ b/messages-ton.options
@@ -4,6 +4,7 @@ TonSignTx.address_n max_count:8
 TonSignTx.coin_name max_size:21
 TonSignTx.raw_tx max_size:1024
 TonSignTx.to_address max_size:50
+TonSignTx.memo max_size:121
 TonAddress.address max_size:50
 TonAddress.raw_address max_size:70
 TonSignedTx.signature max_size:64

--- a/messages-ton.proto
+++ b/messages-ton.proto
@@ -35,18 +35,32 @@ message TonAddress {
 
 /**
  * Request: ask device to sign TON transaction
+ *
+ * Two modes:
+ * 1. Clear-signing (preferred): provide to_address + amount + seqno + expire_at.
+ *    Device reconstructs the v4r2 unsigned body cell, computes its hash,
+ *    and verifies it matches raw_tx before signing. Shows "TON Transfer"
+ *    confirmation with verified amount and recipient.
+ *
+ * 2. Blind-signing (fallback): provide only raw_tx. Device signs the hash
+ *    directly with a blind-sign warning. Used for non-standard transactions.
+ *
  * @start
  * @next TonSignedTx
  */
 message TonSignTx {
     repeated uint32 address_n = 1;                // BIP-32 path to derive the key from master node
     optional string coin_name = 2 [default='Ton'];
-    optional bytes raw_tx = 3;                    // Raw transaction data (serialized by client)
+    optional bytes raw_tx = 3;                    // 32-byte unsigned body cell hash (always required)
     optional uint32 expire_at = 4;                // Transaction expiration timestamp
     optional uint32 seqno = 5;                    // Wallet sequence number
-    optional sint32 workchain = 6 [default=0];    // Workchain ID (-1 or 0)
-    optional string to_address = 7;               // Destination address (for display)
-    optional uint64 amount = 8;                   // Transfer amount in nanoTON (for display)
+    optional sint32 workchain = 6 [default=0];    // Destination workchain ID (-1 or 0)
+    optional string to_address = 7;               // Destination address (user-friendly base64)
+    optional uint64 amount = 8;                   // Transfer amount in nanoTON
+    // Clear-signing fields (new)
+    optional bool bounce = 9;                     // Message bounce flag (default true for clear-sign)
+    optional string memo = 10;                    // Optional text memo/comment
+    optional bool is_deploy = 11;                 // True if wallet needs StateInit (first tx)
 }
 
 /**

--- a/messages-tron.proto
+++ b/messages-tron.proto
@@ -30,20 +30,47 @@ message TronAddress {
 }
 
 /**
+ * Structured TransferContract for reconstruct-then-sign
+ */
+message TronTransferContract {
+    optional string to_address = 1;               // Base58 "T..." destination (max 35)
+    optional uint64 amount = 2;                   // Amount in SUN
+}
+
+/**
+ * Structured TriggerSmartContract for reconstruct-then-sign
+ */
+message TronTriggerSmartContract {
+    optional string contract_address = 1;         // Base58 smart contract address (max 35)
+    optional bytes data = 2;                      // ABI-encoded call data (max 512)
+    optional uint64 call_value = 3;               // TRX sent with call (in SUN)
+}
+
+/**
  * Request: ask device to sign TRON transaction
  * @start
  * @next TronSignedTx
+ *
+ * Two modes:
+ * 1. Legacy blind-sign: provide raw_data (shows warning)
+ * 2. Structured reconstruct-then-sign: provide transfer or trigger_smart
+ *    plus ref_block_bytes, ref_block_hash, expiration, timestamp
  */
 message TronSignTx {
     repeated uint32 address_n = 1;                // BIP-32 path to derive the key from master node
     optional string coin_name = 2 [default='Tron'];
-    optional bytes raw_data = 3;                  // Raw transaction data (serialized by client)
-    optional bytes ref_block_bytes = 4;           // Reference block bytes
-    optional bytes ref_block_hash = 5;            // Reference block hash
-    optional uint64 expiration = 6;               // Transaction expiration timestamp
-    optional string contract_type = 7;            // Contract type (e.g., "TransferContract")
-    optional string to_address = 8;               // Destination address (for display)
-    optional uint64 amount = 9;                   // Transfer amount in SUN (for display)
+    optional bytes raw_data = 3;                  // Legacy: raw transaction data (blind-sign with warning)
+    optional bytes ref_block_bytes = 4;           // Reference block bytes (2 bytes)
+    optional bytes ref_block_hash = 5;            // Reference block hash (8 bytes)
+    optional uint64 expiration = 6;               // Transaction expiration timestamp (ms)
+    optional string contract_type = 7;            // DEPRECATED: use transfer/trigger_smart instead
+    optional string to_address = 8;               // DEPRECATED: use transfer/trigger_smart instead
+    optional uint64 amount = 9;                   // DEPRECATED: use transfer/trigger_smart instead
+    optional TronTransferContract transfer = 10;  // Structured: TRX transfer
+    optional TronTriggerSmartContract trigger_smart = 11; // Structured: smart contract call
+    optional uint64 fee_limit = 12;               // Fee limit for smart contracts (in SUN)
+    optional uint64 timestamp = 13;               // Transaction creation timestamp (ms)
+    optional bytes data = 14;                     // Transaction memo/note (max 256 bytes)
 }
 
 /**
@@ -52,4 +79,5 @@ message TronSignTx {
  */
 message TronSignedTx {
     optional bytes signature = 1;                 // ECDSA signature (65 bytes: r + s + recovery_id)
+    optional bytes serialized_tx = 2;             // Reconstructed raw_data bytes (for host verification)
 }

--- a/messages-zcash.options
+++ b/messages-zcash.options
@@ -1,0 +1,33 @@
+ZcashSignPCZT.address_n max_count:8
+ZcashSignPCZT.pczt_data max_size:4096
+ZcashSignPCZT.header_digest max_size:32
+ZcashSignPCZT.transparent_digest max_size:32
+ZcashSignPCZT.sapling_digest max_size:32
+ZcashSignPCZT.orchard_digest max_size:32
+ZcashSignPCZT.orchard_anchor max_size:32
+
+ZcashPCZTAction.alpha max_size:32
+ZcashPCZTAction.sighash max_size:32
+ZcashPCZTAction.cv_net max_size:32
+ZcashPCZTAction.nullifier max_size:32
+ZcashPCZTAction.cmx max_size:32
+ZcashPCZTAction.epk max_size:32
+ZcashPCZTAction.enc_compact max_size:52
+ZcashPCZTAction.enc_memo max_size:512
+ZcashPCZTAction.enc_noncompact max_size:612
+ZcashPCZTAction.rk max_size:32
+ZcashPCZTAction.out_ciphertext max_size:80
+
+ZcashSignedPCZT.signatures max_count:64 max_size:64
+ZcashSignedPCZT.txid max_size:32
+
+ZcashGetOrchardFVK.address_n max_count:8
+
+ZcashOrchardFVK.ak max_size:32
+ZcashOrchardFVK.nk max_size:32
+ZcashOrchardFVK.rivk max_size:32
+
+ZcashTransparentInput.sighash max_size:32
+ZcashTransparentInput.address_n max_count:8
+
+ZcashTransparentSig.signature max_size:73

--- a/messages-zcash.proto
+++ b/messages-zcash.proto
@@ -1,0 +1,117 @@
+/*
+ * Messages (Zcash specific) for KeepKey Communication
+ *
+ * Zcash shielded transaction signing via PCZT (Partially Constructed
+ * Zcash Transaction) format. Supports Orchard spend authorization.
+ */
+
+syntax = "proto2";
+
+// Sugar for easier handling in Java
+option java_package = "com.keepkey.deviceprotocol";
+option java_outer_classname = "KeepKeyMessageZcash";
+
+/**
+ * Request: Sign a Zcash shielded transaction (PCZT format)
+ *
+ * The PCZT contains pre-constructed transaction data with proofs.
+ * The device derives spend authorization keys, computes the sighash,
+ * and returns RedPallas signatures for each Orchard action.
+ *
+ * @next ZcashPCZTActionAck
+ * @next Failure
+ */
+message ZcashSignPCZT {
+    repeated uint32 address_n = 1;              // ZIP-32 derivation path [32', 133', account']
+    optional uint32 account = 2;                // Account index (alternative to full path)
+    optional bytes pczt_data = 3;               // Serialized PCZT data (may be chunked)
+    optional uint32 n_actions = 4;              // Number of Orchard actions to sign
+    optional uint64 total_amount = 5;           // Total ZEC amount (zatoshis) for user confirmation
+    optional uint64 fee = 6;                    // Transaction fee (zatoshis)
+    optional uint32 branch_id = 7;              // Consensus branch ID
+    // Phase 2a: sub-digests for on-device sighash computation
+    optional bytes header_digest = 8;           // 32-byte pre-computed header digest
+    optional bytes transparent_digest = 9;      // 32-byte transparent digest (or empty)
+    optional bytes sapling_digest = 10;         // 32-byte sapling digest (or empty)
+    optional bytes orchard_digest = 11;         // 32-byte orchard digest
+    // Phase 2b: bundle metadata for orchard digest verification
+    optional uint32 orchard_flags = 12;         // Orchard bundle flags byte
+    optional int64 orchard_value_balance = 13;  // Orchard value balance (LE i64)
+    optional bytes orchard_anchor = 14;         // 32-byte orchard anchor
+}
+
+/**
+ * Per-action signing data extracted from PCZT.
+ * Sent as individual messages for streaming large transactions.
+ *
+ * @next ZcashSignedPCZT
+ * @next ZcashPCZTActionAck
+ * @next Failure
+ */
+message ZcashPCZTAction {
+    optional uint32 index = 1;              // Action index within the Orchard bundle
+    optional bytes alpha = 2;               // 32-byte spend authorization randomizer
+    optional bytes sighash = 3;             // 32-byte transaction sighash (ZIP 244) - legacy mode
+    optional bytes cv_net = 4;              // 32-byte value commitment
+    optional uint64 value = 5;              // Action value in zatoshis (for display)
+    optional bool is_spend = 6;             // True if this action spends a note
+    // Phase 2b: action fields for incremental orchard digest verification
+    optional bytes nullifier = 7;           // 32-byte nullifier
+    optional bytes cmx = 8;                 // 32-byte note commitment
+    optional bytes epk = 9;                 // 32-byte ephemeral key
+    optional bytes enc_compact = 10;        // 52-byte compact encrypted note
+    optional bytes enc_memo = 11;           // 512-byte encrypted memo
+    optional bytes enc_noncompact = 12;     // Remaining encrypted note bytes
+    optional bytes rk = 13;                 // 32-byte randomized verification key
+    optional bytes out_ciphertext = 14;     // 80-byte output ciphertext
+}
+
+/**
+ * Response: Acknowledgment requesting next action data
+ *
+ * @prev ZcashSignPCZT
+ * @prev ZcashPCZTAction
+ */
+message ZcashPCZTActionAck {
+    optional uint32 next_index = 1;         // Index of next action to process
+}
+
+/**
+ * Response: Signed PCZT with spend authorization signatures
+ *
+ * @prev ZcashPCZTAction
+ */
+message ZcashSignedPCZT {
+    repeated bytes signatures = 1;          // 64-byte RedPallas signatures, one per action
+    optional bytes txid = 2;               // 32-byte computed transaction ID
+}
+
+/**
+ * Request: Get the Orchard Full Viewing Key for a given account.
+ *
+ * The FVK (ak, nk, rivk) is safe to export - it allows viewing
+ * transactions but cannot spend funds. Used to construct unified addresses.
+ *
+ * @next ZcashOrchardFVK
+ * @next Failure
+ */
+message ZcashGetOrchardFVK {
+    repeated uint32 address_n = 1;          // ZIP-32 derivation path [32', 133', account']
+    optional uint32 account = 2;            // Account index (alternative to full path)
+    optional bool show_display = 3;         // Show on device display
+}
+
+/**
+ * Response: Orchard Full Viewing Key components.
+ *
+ * ak = [ask]G on Pallas curve (serialized point, 32 bytes)
+ * nk = nullifier deriving key (32 bytes)
+ * rivk = commitment randomness key (32 bytes)
+ *
+ * @prev ZcashGetOrchardFVK
+ */
+message ZcashOrchardFVK {
+    optional bytes ak = 1;                  // 32-byte authorizing key (Pallas point)
+    optional bytes nk = 2;                  // 32-byte nullifier deriving key
+    optional bytes rivk = 3;               // 32-byte commitment randomness key
+}

--- a/messages-zcash.proto
+++ b/messages-zcash.proto
@@ -38,6 +38,8 @@ message ZcashSignPCZT {
     optional uint32 orchard_flags = 12;         // Orchard bundle flags byte
     optional int64 orchard_value_balance = 13;  // Orchard value balance (LE i64)
     optional bytes orchard_anchor = 14;         // 32-byte orchard anchor
+    // Phase 3: transparent shielding support
+    optional uint32 n_transparent_inputs = 30;  // 0 for shielded-only (default), >0 for hybrid shielding tx
 }
 
 /**
@@ -114,4 +116,35 @@ message ZcashOrchardFVK {
     optional bytes ak = 1;                  // 32-byte authorizing key (Pallas point)
     optional bytes nk = 2;                  // 32-byte nullifier deriving key
     optional bytes rivk = 3;               // 32-byte commitment randomness key
+}
+
+/**
+ * Request: Transparent input data for hybrid shielding transactions.
+ * Sent one per transparent input during the transparent signing phase.
+ * The device ECDSA-signs the per-input sighash with the secp256k1 key
+ * at the provided BIP44 path.
+ *
+ * Flow: after ZcashSignPCZT with n_transparent_inputs > 0, the device
+ * responds with ZcashPCZTActionAck. For each transparent input, the host
+ * sends ZcashTransparentInput and receives ZcashTransparentSig. After
+ * all transparent inputs, the device transitions to the Orchard phase.
+ *
+ * @next ZcashTransparentSig
+ * @next Failure
+ */
+message ZcashTransparentInput {
+    required uint32 index = 1;              // Input index within the transaction
+    required bytes sighash = 2;             // 32-byte per-input sighash (host-computed, ZIP-244)
+    repeated uint32 address_n = 3;          // BIP44 path [44', 133', 0', 0, 0]
+    optional uint64 amount = 4;             // Input value in zatoshis (for display verification)
+}
+
+/**
+ * Response: ECDSA signature for a transparent input.
+ *
+ * @prev ZcashTransparentInput
+ */
+message ZcashTransparentSig {
+    required bytes signature = 1;           // DER ECDSA signature (72-73 bytes)
+    optional uint32 next_index = 2;         // Next transparent input index, or 0xFF = done
 }

--- a/messages.proto
+++ b/messages.proto
@@ -742,8 +742,10 @@ message CipheredKeyValue {
 //////////////////////
 
 /**
- * Request: Ask device to derive a BIP-85 child mnemonic
- * @next Bip85Mnemonic
+ * Request: Ask device to derive and display a BIP-85 child mnemonic.
+ * The mnemonic is shown on the device screen only — never sent over USB.
+ * @next Success
+ * @next Failure
  */
 message GetBip85Mnemonic {
   required uint32 word_count = 1; // number of words in derived mnemonic (12, 18, or 24)
@@ -751,11 +753,13 @@ message GetBip85Mnemonic {
 }
 
 /**
- * Response: Contains BIP-85 derived child mnemonic
+ * Response: Contains BIP-85 derived child mnemonic (DEPRECATED).
+ * Firmware >= 7.14.0 responds with Success instead — mnemonic is display-only.
+ * Retained for wire compatibility with older firmware.
  * @prev GetBip85Mnemonic
  */
 message Bip85Mnemonic {
-  required string mnemonic = 1; // BIP-85 derived mnemonic
+  required string mnemonic = 1; // BIP-85 derived mnemonic (legacy, no longer sent)
 }
 
 //////////////////////////////////

--- a/messages.proto
+++ b/messages.proto
@@ -210,6 +210,8 @@ enum MessageType {
   MessageType_ZcashSignedPCZT = 1303 [ (wire_out) = true ];
   MessageType_ZcashGetOrchardFVK = 1304 [ (wire_in) = true ];
   MessageType_ZcashOrchardFVK = 1305 [ (wire_out) = true ];
+  MessageType_ZcashTransparentInput = 1306 [ (wire_in) = true ];
+  MessageType_ZcashTransparentSig = 1307 [ (wire_out) = true ];
 
   // TRON
   MessageType_TronGetAddress = 1400 [ (wire_in) = true ];

--- a/messages.proto
+++ b/messages.proto
@@ -203,6 +203,14 @@ enum MessageType {
   MessageType_MayachainMsgAck = 1204 [ (wire_in) = true ];
   MessageType_MayachainSignedTx = 1205 [ (wire_out) = true ];
 
+  // Zcash (Orchard shielded)
+  MessageType_ZcashSignPCZT = 1300 [ (wire_in) = true ];
+  MessageType_ZcashPCZTAction = 1301 [ (wire_in) = true ];
+  MessageType_ZcashPCZTActionAck = 1302 [ (wire_out) = true ];
+  MessageType_ZcashSignedPCZT = 1303 [ (wire_out) = true ];
+  MessageType_ZcashGetOrchardFVK = 1304 [ (wire_in) = true ];
+  MessageType_ZcashOrchardFVK = 1305 [ (wire_out) = true ];
+
   // TRON
   MessageType_TronGetAddress = 1400 [ (wire_in) = true ];
   MessageType_TronAddress = 1401 [ (wire_out) = true ];

--- a/messages.proto
+++ b/messages.proto
@@ -97,6 +97,10 @@ enum MessageType {
   MessageType_EthereumTypedDataSignature = 113 [ (wire_out) = true ];
   MessageType_Ethereum712TypesValues = 114 [ (wire_in) = true ];
 
+  // Ethereum Clear Signing
+  MessageType_EthereumTxMetadata = 115 [ (wire_in) = true ];
+  MessageType_EthereumMetadataAck = 116 [ (wire_out) = true ];
+
   // BIP-85
   MessageType_GetBip85Mnemonic = 120 [ (wire_in) = true ];
   MessageType_Bip85Mnemonic = 121 [ (wire_out) = true ];


### PR DESCRIPTION
## Summary
- Zcash Orchard shielded transaction protocol (IDs 1300-1307): PCZT signing, FVK, transparent shielding
- TON clear-signing fields: to_address, amount, seqno, expire_at, memo
- EVM clear-signing metadata: EthereumTxMetadata (115), EthereumMetadataAck (116)
- BIP-85 contract update: firmware responds with Success, not Bip85Mnemonic (display-only)
- Solana SolanaTokenInfo for SPL token display
- TRON structured signing fields (TronTransferContract, TronTriggerSmartContract)
- nanopb options for all new proto fields

All changes are additive — no breaking changes to existing message IDs or field layouts.

## Test plan
- [ ] Verify proto compilation with nanopb
- [ ] Verify message ID uniqueness (no conflicts)
- [ ] Verify backwards compatibility with existing firmware