### PR TITLE
feat(bip85): update proto contract — display-only response

### DIFF
--- a/messages.proto
+++ b/messages.proto
@@ -728,8 +728,10 @@ message CipheredKeyValue {
 //////////////////////
 
 /**
- * Request: Ask device to derive a BIP-85 child mnemonic
- * @next Bip85Mnemonic
+ * Request: Ask device to derive and display a BIP-85 child mnemonic.
+ * The mnemonic is shown on the device screen only — never sent over USB.
+ * @next Success
+ * @next Failure
  */
 message GetBip85Mnemonic {
   required uint32 word_count = 1; // number of words in derived mnemonic (12, 18, or 24)
@@ -737,11 +739,13 @@ message GetBip85Mnemonic {
 }
 
 /**
- * Response: Contains BIP-85 derived child mnemonic
+ * Response: Contains BIP-85 derived child mnemonic (DEPRECATED).
+ * Firmware >= 7.14.0 responds with Success instead — mnemonic is display-only.
+ * Retained for wire compatibility with older firmware.
  * @prev GetBip85Mnemonic
  */
 message Bip85Mnemonic {
-  required string mnemonic = 1; // BIP-85 derived mnemonic
+  required string mnemonic = 1; // BIP-85 derived mnemonic (legacy, no longer sent)
 }
 
 //////////////////////////////////


### PR DESCRIPTION
## Summary
- `GetBip85Mnemonic` now returns `Success` — mnemonic shown on device screen only, never sent over USB
- `Bip85Mnemonic` message retained for wire compatibility with older firmware
- Security improvement: prevents host-side mnemonic exposure

## Files
- `messages.proto` — doc/comment updates only, no wire ID changes

## Firmware dependency
Unblocks keepkey/keepkey-firmware BIP-85 display-only feature (7.14.0)

## Test plan
- [ ] `protoc` compiles cleanly
- [ ] Backward-compatible — old firmware still sends `Bip85Mnemonic`