### PR TITLE
feat(evm): EthereumTxMetadata for clear-signing

### DIFF
--- a/messages-ethereum.options
+++ b/messages-ethereum.options
@@ -1,0 +1,2 @@
+EthereumTxMetadata.signed_payload max_size:1024
+EthereumMetadataAck.display_summary max_size:32

--- a/messages-ethereum.proto
+++ b/messages-ethereum.proto
@@ -87,6 +87,32 @@ message EthereumTxAck {
 	optional bytes data_chunk = 1;			// Bytes from transaction payload (<= 1024 bytes)
 }
 
+///////////////////////////////////////////
+// Ethereum: Clear signing metadata     //
+///////////////////////////////////////////
+
+/**
+ * Request: Send signed metadata before EthereumSignTx for clear signing.
+ * Host sends this BEFORE EthereumSignTx when metadata is available.
+ * If not sent, existing signing flow is unchanged (backwards compatible).
+ * @next EthereumMetadataAck
+ * @next Failure
+ */
+message EthereumTxMetadata {
+	optional bytes signed_payload = 1;		// Canonical signed metadata blob
+	optional uint32 metadata_version = 2;		// Schema version (defaults to 1)
+	optional uint32 key_id = 3;			// Embedded verification key slot (0-3)
+}
+
+/**
+ * Response: Result of metadata verification.
+ * @prev EthereumTxMetadata
+ */
+message EthereumMetadataAck {
+	required uint32 classification = 1;		// 0=OPAQUE, 1=VERIFIED, 2=MALFORMED
+	optional string display_summary = 2;		// Brief result for host logging
+}
+
 ////////////////////////////////////////
 // Ethereum: Message signing messages //
 ////////////////////////////////////////

--- a/messages.proto
+++ b/messages.proto
@@ -101,6 +101,9 @@ enum MessageType {
   MessageType_GetBip85Mnemonic = 120 [ (wire_in) = true ];
   MessageType_Bip85Mnemonic = 121 [ (wire_out) = true ];
 
+  // Ethereum Clear Signing
+  MessageType_EthereumTxMetadata = 115 [ (wire_in) = true ];
+  MessageType_EthereumMetadataAck = 116 [ (wire_out) = true ];
   // Ripple
   MessageType_RippleGetAddress = 400 [ (wire_in) = true ];
   MessageType_RippleAddress = 401 [ (wire_out) = true ];


### PR DESCRIPTION
## Summary
- New `EthereumTxMetadata` message (signed_payload, metadata_version, key_id)
- New `EthereumMetadataAck` response (classification, display_summary)
- Wire IDs 115-116
- nanopb options: payload max 1024 bytes, summary max 32 chars

Enables firmware to verify signed transaction metadata from an external
insight service before confirming EVM transactions.

## Files
- `messages-ethereum.proto` — two new messages
- `messages-ethereum.options` — nanopb size limits
- `messages.proto` — wire ID registration (115-116)

## Firmware dependency
Unblocks keepkey/keepkey-firmware EVM clear-signing feature (7.14.0)

## Test plan
- [ ] `protoc` compiles cleanly
- [ ] Wire IDs 115-116 don't conflict (gap between existing ~70s and BIP-85 120)
- [ ] nanopb generation succeeds