### PR TITLE
feat(solana): add SolanaTokenInfo and nanopb options

### DIFF
--- a/messages-solana.options
+++ b/messages-solana.options
@@ -1,0 +1,15 @@
+SolanaGetAddress.address_n max_count:8
+SolanaGetAddress.coin_name max_size:21
+SolanaSignTx.address_n max_count:8
+SolanaSignTx.coin_name max_size:21
+SolanaSignTx.raw_tx max_size:1232
+SolanaSignTx.token_info max_count:4
+SolanaTokenInfo.mint max_size:32
+SolanaTokenInfo.symbol max_size:13
+SolanaAddress.address max_size:45
+SolanaSignedTx.signature max_size:64
+SolanaSignMessage.address_n max_count:8
+SolanaSignMessage.coin_name max_size:21
+SolanaSignMessage.message max_size:1024
+SolanaMessageSignature.public_key max_size:32
+SolanaMessageSignature.signature max_size:64

--- a/messages-solana.proto
+++ b/messages-solana.proto
@@ -31,6 +31,15 @@ message SolanaAddress {
 }
 
 /**
+ * Host-provided token metadata for SPL token display
+ */
+message SolanaTokenInfo {
+    optional bytes mint = 1;                // 32-byte mint public key
+    optional string symbol = 2;            // Token symbol e.g. "USDC" (max 12)
+    optional uint32 decimals = 3;          // Token decimals e.g. 6
+}
+
+/**
  * Request: Ask device to sign a raw Solana transaction
  * @next SolanaSignedTx
  * @next Failure
@@ -39,6 +48,7 @@ message SolanaSignTx {
     repeated uint32 address_n = 1;          // BIP-32/BIP-44 path to signing key
     optional string coin_name = 2 [default = "Solana"];
     optional bytes raw_tx = 3;              // Serialized Solana transaction bytes
+    repeated SolanaTokenInfo token_info = 4; // Token metadata for display (max 4)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "clean": "rm -rf ./lib/*.js ./lib/*.ts",
     "build": "npm run build:js && npm run build:json && npm run build:postprocess",
-    "build:js": "protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./lib --ts_out=./lib types.proto messages.proto messages-ethereum.proto messages-eos.proto messages-nano.proto messages-cosmos.proto messages-binance.proto messages-ripple.proto messages-tendermint.proto messages-thorchain.proto messages-osmosis.proto messages-mayachain.proto",
-    "build:json": "pbjs --keep-case -t json ./types.proto ./messages.proto ./messages-ethereum.proto ./messages-eos.proto ./messages-nano.proto ./messages-cosmos.proto ./messages-binance.proto ./messages-ripple.proto ./messages-tendermint.proto ./messages-thorchain.proto ./messages-osmosis.proto ./messages-mayachain.proto > ./lib/proto.json",
+    "build:js": "protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./lib --ts_out=./lib types.proto messages.proto messages-ethereum.proto messages-eos.proto messages-nano.proto messages-cosmos.proto messages-binance.proto messages-ripple.proto messages-tendermint.proto messages-thorchain.proto messages-osmosis.proto messages-mayachain.proto messages-solana.proto",
+    "build:json": "pbjs --keep-case -t json ./types.proto ./messages.proto ./messages-ethereum.proto ./messages-eos.proto ./messages-nano.proto ./messages-cosmos.proto ./messages-binance.proto ./messages-ripple.proto ./messages-tendermint.proto ./messages-thorchain.proto ./messages-osmosis.proto ./messages-mayachain.proto ./messages-solana.proto > ./lib/proto.json",
     "build:postprocess": "find ./lib -name \"*.js\" -exec sed -i '' -e \"s/var global = Function(\\'return this\\')();/var global = (function(){ return this }).call(null);/g\" {} \\;",
     "prepublishOnly": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary
- New `SolanaTokenInfo` message for SPL token display (mint, symbol, decimals)
- `token_info` repeated field on `SolanaSignTx` (max 4 entries)
- nanopb size limits for all Solana fields
- Added `messages-solana.proto` to package build scripts

Enables firmware clear-signing of SPL token transfers with symbol display.

## Files
- `messages-solana.proto` — new message + field
- `messages-solana.options` — nanopb limits (new file)
- `package.json` — build script updated

## Firmware dependency
Unblocks keepkey/keepkey-firmware Solana support (7.14.0)

## Test plan
- [ ] `protoc` compiles cleanly
- [ ] `npm run build` succeeds and emits Solana types
- [ ] No message ID conflicts