### PR TITLE
feat(tron): structured fields for clear-signing

### DIFF
--- a/messages-tron.options
+++ b/messages-tron.options
@@ -9,3 +9,8 @@ TronSignTx.contract_type max_size:50
 TronSignTx.to_address max_size:35
 TronAddress.address max_size:35
 TronSignedTx.signature max_size:65
+TronTransferContract.to_address max_size:35
+TronTriggerSmartContract.contract_address max_size:35
+TronTriggerSmartContract.data max_size:512
+TronSignTx.data max_size:256
+TronSignedTx.serialized_tx max_size:1024

--- a/messages-tron.proto
+++ b/messages-tron.proto
@@ -30,20 +30,47 @@ message TronAddress {
 }
 
 /**
+ * Structured TransferContract for reconstruct-then-sign
+ */
+message TronTransferContract {
+    optional string to_address = 1;               // Base58 "T..." destination (max 35)
+    optional uint64 amount = 2;                   // Amount in SUN
+}
+
+/**
+ * Structured TriggerSmartContract for reconstruct-then-sign
+ */
+message TronTriggerSmartContract {
+    optional string contract_address = 1;         // Base58 smart contract address (max 35)
+    optional bytes data = 2;                      // ABI-encoded call data (max 512)
+    optional uint64 call_value = 3;               // TRX sent with call (in SUN)
+}
+
+/**
  * Request: ask device to sign TRON transaction
  * @start
  * @next TronSignedTx
+ *
+ * Two modes:
+ * 1. Legacy blind-sign: provide raw_data (shows warning)
+ * 2. Structured reconstruct-then-sign: provide transfer or trigger_smart
+ *    plus ref_block_bytes, ref_block_hash, expiration, timestamp
  */
 message TronSignTx {
     repeated uint32 address_n = 1;                // BIP-32 path to derive the key from master node
     optional string coin_name = 2 [default='Tron'];
-    optional bytes raw_data = 3;                  // Raw transaction data (serialized by client)
-    optional bytes ref_block_bytes = 4;           // Reference block bytes
-    optional bytes ref_block_hash = 5;            // Reference block hash
-    optional uint64 expiration = 6;               // Transaction expiration timestamp
-    optional string contract_type = 7;            // Contract type (e.g., "TransferContract")
-    optional string to_address = 8;               // Destination address (for display)
-    optional uint64 amount = 9;                   // Transfer amount in SUN (for display)
+    optional bytes raw_data = 3;                  // Legacy: raw transaction data (blind-sign with warning)
+    optional bytes ref_block_bytes = 4;           // Reference block bytes (2 bytes)
+    optional bytes ref_block_hash = 5;            // Reference block hash (8 bytes)
+    optional uint64 expiration = 6;               // Transaction expiration timestamp (ms)
+    optional string contract_type = 7;            // DEPRECATED: use transfer/trigger_smart instead
+    optional string to_address = 8;               // DEPRECATED: use transfer/trigger_smart instead
+    optional uint64 amount = 9;                   // DEPRECATED: use transfer/trigger_smart instead
+    optional TronTransferContract transfer = 10;  // Structured: TRX transfer
+    optional TronTriggerSmartContract trigger_smart = 11; // Structured: smart contract call
+    optional uint64 fee_limit = 12;               // Fee limit for smart contracts (in SUN)
+    optional uint64 timestamp = 13;               // Transaction creation timestamp (ms)
+    optional bytes data = 14;                     // Transaction memo/note (max 256 bytes)
 }
 
 /**
@@ -52,4 +79,5 @@ message TronSignTx {
  */
 message TronSignedTx {
     optional bytes signature = 1;                 // ECDSA signature (65 bytes: r + s + recovery_id)
+    optional bytes serialized_tx = 2;             // Reconstructed raw_data bytes (for host verification)
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "clean": "rm -rf ./lib/*.js ./lib/*.ts",
     "build": "npm run build:js && npm run build:json && npm run build:postprocess",
-    "build:js": "protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./lib --ts_out=./lib types.proto messages.proto messages-ethereum.proto messages-eos.proto messages-nano.proto messages-cosmos.proto messages-binance.proto messages-ripple.proto messages-tendermint.proto messages-thorchain.proto messages-osmosis.proto messages-mayachain.proto",
-    "build:json": "pbjs --keep-case -t json ./types.proto ./messages.proto ./messages-ethereum.proto ./messages-eos.proto ./messages-nano.proto ./messages-cosmos.proto ./messages-binance.proto ./messages-ripple.proto ./messages-tendermint.proto ./messages-thorchain.proto ./messages-osmosis.proto ./messages-mayachain.proto > ./lib/proto.json",
+    "build:js": "protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./lib --ts_out=./lib types.proto messages.proto messages-ethereum.proto messages-eos.proto messages-nano.proto messages-cosmos.proto messages-binance.proto messages-ripple.proto messages-tendermint.proto messages-thorchain.proto messages-osmosis.proto messages-mayachain.proto messages-tron.proto",
+    "build:json": "pbjs --keep-case -t json ./types.proto ./messages.proto ./messages-ethereum.proto ./messages-eos.proto ./messages-nano.proto ./messages-cosmos.proto ./messages-binance.proto ./messages-ripple.proto ./messages-tendermint.proto ./messages-thorchain.proto ./messages-osmosis.proto ./messages-mayachain.proto ./messages-tron.proto > ./lib/proto.json",
     "build:postprocess": "find ./lib -name \"*.js\" -exec sed -i '' -e \"s/var global = Function(\\'return this\\')();/var global = (function(){ return this }).call(null);/g\" {} \\;",
     "prepublishOnly": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary
- New `TronTransferContract` and `TronTriggerSmartContract` messages
- Structured fields on `TronSignTx` for reconstruct-then-sign mode
- `serialized_tx` on `TronSignedTx` for host verification
- nanopb options for all new string/bytes fields
- Added `messages-tron.proto` to package build scripts

Enables firmware to decode and display TRX/TRC-20 transfers on-device
instead of blind-signing raw transaction bytes.

## Files
- `messages-tron.proto` — new messages + structured fields
- `messages-tron.options` — nanopb limits for new fields
- `package.json` — build script updated

## Firmware dependency
Unblocks keepkey/keepkey-firmware TRON support (7.14.0)

## Test plan
- [ ] `protoc` compiles cleanly
- [ ] `npm run build` succeeds and emits TRON types
- [ ] All string/bytes fields have nanopb bounds