### PR TITLE
feat(ton): clear-signing fields and memo support

### DIFF
--- a/messages-ton.options
+++ b/messages-ton.options
@@ -4,6 +4,7 @@ TonSignTx.address_n max_count:8
 TonSignTx.coin_name max_size:21
 TonSignTx.raw_tx max_size:1024
 TonSignTx.to_address max_size:50
+TonSignTx.memo max_size:121
 TonAddress.address max_size:50
 TonAddress.raw_address max_size:70
 TonSignedTx.signature max_size:64

--- a/messages-ton.proto
+++ b/messages-ton.proto
@@ -35,18 +35,32 @@ message TonAddress {
 
 /**
  * Request: ask device to sign TON transaction
+ *
+ * Two modes:
+ * 1. Clear-signing (preferred): provide to_address + amount + seqno + expire_at.
+ *    Device reconstructs the v4r2 unsigned body cell, computes its hash,
+ *    and verifies it matches raw_tx before signing. Shows "TON Transfer"
+ *    confirmation with verified amount and recipient.
+ *
+ * 2. Blind-signing (fallback): provide only raw_tx. Device signs the hash
+ *    directly with a blind-sign warning. Used for non-standard transactions.
+ *
  * @start
  * @next TonSignedTx
  */
 message TonSignTx {
     repeated uint32 address_n = 1;                // BIP-32 path to derive the key from master node
     optional string coin_name = 2 [default='Ton'];
-    optional bytes raw_tx = 3;                    // Raw transaction data (serialized by client)
+    optional bytes raw_tx = 3;                    // 32-byte unsigned body cell hash (always required)
     optional uint32 expire_at = 4;                // Transaction expiration timestamp
     optional uint32 seqno = 5;                    // Wallet sequence number
-    optional sint32 workchain = 6 [default=0];    // Workchain ID (-1 or 0)
-    optional string to_address = 7;               // Destination address (for display)
-    optional uint64 amount = 8;                   // Transfer amount in nanoTON (for display)
+    optional sint32 workchain = 6 [default=0];    // Destination workchain ID (-1 or 0)
+    optional string to_address = 7;               // Destination address (user-friendly base64)
+    optional uint64 amount = 8;                   // Transfer amount in nanoTON
+    // Clear-signing fields (new)
+    optional bool bounce = 9;                     // Message bounce flag (default true for clear-sign)
+    optional string memo = 10;                    // Optional text memo/comment
+    optional bool is_deploy = 11;                 // True if wallet needs StateInit (first tx)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "clean": "rm -rf ./lib/*.js ./lib/*.ts",
     "build": "npm run build:js && npm run build:json && npm run build:postprocess",
-    "build:js": "protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./lib --ts_out=./lib types.proto messages.proto messages-ethereum.proto messages-eos.proto messages-nano.proto messages-cosmos.proto messages-binance.proto messages-ripple.proto messages-tendermint.proto messages-thorchain.proto messages-osmosis.proto messages-mayachain.proto",
-    "build:json": "pbjs --keep-case -t json ./types.proto ./messages.proto ./messages-ethereum.proto ./messages-eos.proto ./messages-nano.proto ./messages-cosmos.proto ./messages-binance.proto ./messages-ripple.proto ./messages-tendermint.proto ./messages-thorchain.proto ./messages-osmosis.proto ./messages-mayachain.proto > ./lib/proto.json",
+    "build:js": "protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./lib --ts_out=./lib types.proto messages.proto messages-ethereum.proto messages-eos.proto messages-nano.proto messages-cosmos.proto messages-binance.proto messages-ripple.proto messages-tendermint.proto messages-thorchain.proto messages-osmosis.proto messages-mayachain.proto messages-ton.proto",
+    "build:json": "pbjs --keep-case -t json ./types.proto ./messages.proto ./messages-ethereum.proto ./messages-eos.proto ./messages-nano.proto ./messages-cosmos.proto ./messages-binance.proto ./messages-ripple.proto ./messages-tendermint.proto ./messages-thorchain.proto ./messages-osmosis.proto ./messages-mayachain.proto ./messages-ton.proto > ./lib/proto.json",
     "build:postprocess": "find ./lib -name \"*.js\" -exec sed -i '' -e \"s/var global = Function(\\'return this\\')();/var global = (function(){ return this }).call(null);/g\" {} \\;",
     "prepublishOnly": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary
- `to_address`, `amount`, `seqno`, `expire_at`, `memo` fields on `TonSignTx`
- All fields optional — backward compatible with blind-sign mode
- `memo` nanopb max_size:121
- Added `messages-ton.proto` to package build scripts

Enables firmware v4r2 body cell hash verification for clear-sign UX.
Device reconstructs unsigned body cell, verifies hash matches raw_tx.

## Files
- `messages-ton.proto` — new optional fields + mode documentation
- `messages-ton.options` — memo size limit
- `package.json` — build script updated

## Firmware dependency
Unblocks keepkey/keepkey-firmware TON support (7.14.0)

## Test plan
- [ ] `protoc` compiles cleanly
- [ ] `npm run build` succeeds and emits TON types
- [ ] Backward compatible (existing TonSignTx with only raw_tx still works)