### PR TITLE
feat(zcash): Orchard shielded transaction protocol

### DIFF
--- a/messages-zcash.options
+++ b/messages-zcash.options
@@ -1,0 +1,33 @@
+ZcashSignPCZT.address_n max_count:8
+ZcashSignPCZT.pczt_data max_size:4096
+ZcashSignPCZT.header_digest max_size:32
+ZcashSignPCZT.transparent_digest max_size:32
+ZcashSignPCZT.sapling_digest max_size:32
+ZcashSignPCZT.orchard_digest max_size:32
+ZcashSignPCZT.orchard_anchor max_size:32
+
+ZcashPCZTAction.alpha max_size:32
+ZcashPCZTAction.sighash max_size:32
+ZcashPCZTAction.cv_net max_size:32
+ZcashPCZTAction.nullifier max_size:32
+ZcashPCZTAction.cmx max_size:32
+ZcashPCZTAction.epk max_size:32
+ZcashPCZTAction.enc_compact max_size:52
+ZcashPCZTAction.enc_memo max_size:512
+ZcashPCZTAction.enc_noncompact max_size:612
+ZcashPCZTAction.rk max_size:32
+ZcashPCZTAction.out_ciphertext max_size:80
+
+ZcashSignedPCZT.signatures max_count:64 max_size:64
+ZcashSignedPCZT.txid max_size:32
+
+ZcashGetOrchardFVK.address_n max_count:8
+
+ZcashOrchardFVK.ak max_size:32
+ZcashOrchardFVK.nk max_size:32
+ZcashOrchardFVK.rivk max_size:32
+
+ZcashTransparentInput.sighash max_size:32
+ZcashTransparentInput.address_n max_count:8
+
+ZcashTransparentSig.signature max_size:73

--- a/messages-zcash.proto
+++ b/messages-zcash.proto
@@ -1,0 +1,150 @@
+/*
+ * Messages (Zcash specific) for KeepKey Communication
+ *
+ * Zcash shielded transaction signing via PCZT (Partially Constructed
+ * Zcash Transaction) format. Supports Orchard spend authorization.
+ */
+
+syntax = "proto2";
+
+// Sugar for easier handling in Java
+option java_package = "com.keepkey.deviceprotocol";
+option java_outer_classname = "KeepKeyMessageZcash";
+
+/**
+ * Request: Sign a Zcash shielded transaction (PCZT format)
+ *
+ * The PCZT contains pre-constructed transaction data with proofs.
+ * The device derives spend authorization keys, computes the sighash,
+ * and returns RedPallas signatures for each Orchard action.
+ *
+ * @next ZcashPCZTActionAck
+ * @next Failure
+ */
+message ZcashSignPCZT {
+    repeated uint32 address_n = 1;              // ZIP-32 derivation path [32', 133', account']
+    optional uint32 account = 2;                // Account index (alternative to full path)
+    optional bytes pczt_data = 3;               // Serialized PCZT data (may be chunked)
+    optional uint32 n_actions = 4;              // Number of Orchard actions to sign
+    optional uint64 total_amount = 5;           // Total ZEC amount (zatoshis) for user confirmation
+    optional uint64 fee = 6;                    // Transaction fee (zatoshis)
+    optional uint32 branch_id = 7;              // Consensus branch ID
+    // Phase 2a: sub-digests for on-device sighash computation
+    optional bytes header_digest = 8;           // 32-byte pre-computed header digest
+    optional bytes transparent_digest = 9;      // 32-byte transparent digest (or empty)
+    optional bytes sapling_digest = 10;         // 32-byte sapling digest (or empty)
+    optional bytes orchard_digest = 11;         // 32-byte orchard digest
+    // Phase 2b: bundle metadata for orchard digest verification
+    optional uint32 orchard_flags = 12;         // Orchard bundle flags byte
+    optional int64 orchard_value_balance = 13;  // Orchard value balance (LE i64)
+    optional bytes orchard_anchor = 14;         // 32-byte orchard anchor
+    // Phase 3: transparent shielding support
+    optional uint32 n_transparent_inputs = 30;  // 0 for shielded-only (default), >0 for hybrid shielding tx
+}
+
+/**
+ * Per-action signing data extracted from PCZT.
+ * Sent as individual messages for streaming large transactions.
+ *
+ * @next ZcashSignedPCZT
+ * @next ZcashPCZTActionAck
+ * @next Failure
+ */
+message ZcashPCZTAction {
+    optional uint32 index = 1;              // Action index within the Orchard bundle
+    optional bytes alpha = 2;               // 32-byte spend authorization randomizer
+    optional bytes sighash = 3;             // 32-byte transaction sighash (ZIP 244) - legacy mode
+    optional bytes cv_net = 4;              // 32-byte value commitment
+    optional uint64 value = 5;              // Action value in zatoshis (for display)
+    optional bool is_spend = 6;             // True if this action spends a note
+    // Phase 2b: action fields for incremental orchard digest verification
+    optional bytes nullifier = 7;           // 32-byte nullifier
+    optional bytes cmx = 8;                 // 32-byte note commitment
+    optional bytes epk = 9;                 // 32-byte ephemeral key
+    optional bytes enc_compact = 10;        // 52-byte compact encrypted note
+    optional bytes enc_memo = 11;           // 512-byte encrypted memo
+    optional bytes enc_noncompact = 12;     // Remaining encrypted note bytes
+    optional bytes rk = 13;                 // 32-byte randomized verification key
+    optional bytes out_ciphertext = 14;     // 80-byte output ciphertext
+}
+
+/**
+ * Response: Acknowledgment requesting next action data
+ *
+ * @prev ZcashSignPCZT
+ * @prev ZcashPCZTAction
+ */
+message ZcashPCZTActionAck {
+    optional uint32 next_index = 1;         // Index of next action to process
+}
+
+/**
+ * Response: Signed PCZT with spend authorization signatures
+ *
+ * @prev ZcashPCZTAction
+ */
+message ZcashSignedPCZT {
+    repeated bytes signatures = 1;          // 64-byte RedPallas signatures, one per action
+    optional bytes txid = 2;               // 32-byte computed transaction ID
+}
+
+/**
+ * Request: Get the Orchard Full Viewing Key for a given account.
+ *
+ * The FVK (ak, nk, rivk) is safe to export - it allows viewing
+ * transactions but cannot spend funds. Used to construct unified addresses.
+ *
+ * @next ZcashOrchardFVK
+ * @next Failure
+ */
+message ZcashGetOrchardFVK {
+    repeated uint32 address_n = 1;          // ZIP-32 derivation path [32', 133', account']
+    optional uint32 account = 2;            // Account index (alternative to full path)
+    optional bool show_display = 3;         // Show on device display
+}
+
+/**
+ * Response: Orchard Full Viewing Key components.
+ *
+ * ak = [ask]G on Pallas curve (serialized point, 32 bytes)
+ * nk = nullifier deriving key (32 bytes)
+ * rivk = commitment randomness key (32 bytes)
+ *
+ * @prev ZcashGetOrchardFVK
+ */
+message ZcashOrchardFVK {
+    optional bytes ak = 1;                  // 32-byte authorizing key (Pallas point)
+    optional bytes nk = 2;                  // 32-byte nullifier deriving key
+    optional bytes rivk = 3;               // 32-byte commitment randomness key
+}
+
+/**
+ * Request: Transparent input data for hybrid shielding transactions.
+ * Sent one per transparent input during the transparent signing phase.
+ * The device ECDSA-signs the per-input sighash with the secp256k1 key
+ * at the provided BIP44 path.
+ *
+ * Flow: after ZcashSignPCZT with n_transparent_inputs > 0, the device
+ * responds with ZcashPCZTActionAck. For each transparent input, the host
+ * sends ZcashTransparentInput and receives ZcashTransparentSig. After
+ * all transparent inputs, the device transitions to the Orchard phase.
+ *
+ * @next ZcashTransparentSig
+ * @next Failure
+ */
+message ZcashTransparentInput {
+    required uint32 index = 1;              // Input index within the transaction
+    required bytes sighash = 2;             // 32-byte per-input sighash (host-computed, ZIP-244)
+    repeated uint32 address_n = 3;          // BIP44 path [44', 133', 0', 0, 0]
+    optional uint64 amount = 4;             // Input value in zatoshis (for display verification)
+}
+
+/**
+ * Response: ECDSA signature for a transparent input.
+ *
+ * @prev ZcashTransparentInput
+ */
+message ZcashTransparentSig {
+    required bytes signature = 1;           // DER ECDSA signature (72-73 bytes)
+    optional uint32 next_index = 2;         // Next transparent input index, or 0xFF = done
+}

--- a/messages.proto
+++ b/messages.proto
@@ -203,6 +203,15 @@ enum MessageType {
   MessageType_MayachainMsgAck = 1204 [ (wire_in) = true ];
   MessageType_MayachainSignedTx = 1205 [ (wire_out) = true ];
 
+  // Zcash (Orchard shielded)
+  MessageType_ZcashSignPCZT = 1300 [ (wire_in) = true ];
+  MessageType_ZcashPCZTAction = 1301 [ (wire_in) = true ];
+  MessageType_ZcashPCZTActionAck = 1302 [ (wire_out) = true ];
+  MessageType_ZcashSignedPCZT = 1303 [ (wire_out) = true ];
+  MessageType_ZcashGetOrchardFVK = 1304 [ (wire_in) = true ];
+  MessageType_ZcashOrchardFVK = 1305 [ (wire_out) = true ];
+  MessageType_ZcashTransparentInput = 1306 [ (wire_in) = true ];
+  MessageType_ZcashTransparentSig = 1307 [ (wire_out) = true ];
   // TRON
   MessageType_TronGetAddress = 1400 [ (wire_in) = true ];
   MessageType_TronAddress = 1401 [ (wire_out) = true ];

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "clean": "rm -rf ./lib/*.js ./lib/*.ts",
     "build": "npm run build:js && npm run build:json && npm run build:postprocess",
-    "build:js": "protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./lib --ts_out=./lib types.proto messages.proto messages-ethereum.proto messages-eos.proto messages-nano.proto messages-cosmos.proto messages-binance.proto messages-ripple.proto messages-tendermint.proto messages-thorchain.proto messages-osmosis.proto messages-mayachain.proto",
-    "build:json": "pbjs --keep-case -t json ./types.proto ./messages.proto ./messages-ethereum.proto ./messages-eos.proto ./messages-nano.proto ./messages-cosmos.proto ./messages-binance.proto ./messages-ripple.proto ./messages-tendermint.proto ./messages-thorchain.proto ./messages-osmosis.proto ./messages-mayachain.proto > ./lib/proto.json",
+    "build:js": "protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./lib --ts_out=./lib types.proto messages.proto messages-ethereum.proto messages-eos.proto messages-nano.proto messages-cosmos.proto messages-binance.proto messages-ripple.proto messages-tendermint.proto messages-thorchain.proto messages-osmosis.proto messages-mayachain.proto messages-zcash.proto",
+    "build:json": "pbjs --keep-case -t json ./types.proto ./messages.proto ./messages-ethereum.proto ./messages-eos.proto ./messages-nano.proto ./messages-cosmos.proto ./messages-binance.proto ./messages-ripple.proto ./messages-tendermint.proto ./messages-thorchain.proto ./messages-osmosis.proto ./messages-mayachain.proto ./messages-zcash.proto > ./lib/proto.json",
     "build:postprocess": "find ./lib -name \"*.js\" -exec sed -i '' -e \"s/var global = Function(\\'return this\\')();/var global = (function(){ return this }).call(null);/g\" {} \\;",
     "prepublishOnly": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary
- PCZT streaming protocol: `ZcashSignPCZT` → `ZcashPCZTAction` → `ZcashSignedPCZT`
- Orchard FVK derivation: `ZcashGetOrchardFVK` → `ZcashOrchardFVK`
- Transparent shielding: `ZcashTransparentInput` → `ZcashTransparentSig`
- Wire IDs 1300-1307
- nanopb options for all fields (digests 32B, actions, signatures)
- Added `messages-zcash.proto` to package build scripts

Multi-phase protocol for Zcash Orchard shielded transactions:
1. Session init with amount/fee confirmation
2. Orchard action streaming with on-device digest verification
3. Optional transparent input signing with per-input confirmation

## Files
- `messages-zcash.proto` — new file (150 lines, full protocol)
- `messages-zcash.options` — nanopb limits (new file)
- `messages.proto` — wire ID registration (1300-1307)
- `package.json` — build script updated

## Firmware dependency
Unblocks keepkey/keepkey-firmware Zcash Orchard support (7.14.0)

## Test plan
- [ ] `protoc` compiles cleanly
- [ ] `npm run build` succeeds and emits Zcash types
- [ ] Wire IDs 1300-1307 don't conflict (between Mayachain 1205 and TRON 1400)
- [ ] All bytes/string fields have nanopb bounds