### PR TITLE
feat: ZcashDisplayAddress protocol (IDs 1308-1309)

### DIFF
--- a/messages-zcash.options
+++ b/messages-zcash.options
@@ -31,3 +31,11 @@ ZcashTransparentInput.sighash max_size:32
 ZcashTransparentInput.address_n max_count:8
 
 ZcashTransparentSig.signature max_size:73
+
+ZcashDisplayAddress.address_n max_count:8
+ZcashDisplayAddress.address max_size:256
+ZcashDisplayAddress.ak max_size:32
+ZcashDisplayAddress.nk max_size:32
+ZcashDisplayAddress.rivk max_size:32
+
+ZcashAddress.address max_size:256

--- a/messages-zcash.proto
+++ b/messages-zcash.proto
@@ -148,3 +148,32 @@ message ZcashTransparentSig {
     required bytes signature = 1;           // DER ECDSA signature (72-73 bytes)
     optional uint32 next_index = 2;         // Next transparent input index, or 0xFF = done
 }
+
+/**
+ * Request: Display and verify a Zcash unified address on device.
+ *
+ * The host provides the unified address string and the FVK components
+ * (ak, nk, rivk). The device re-derives its own Orchard keys from seed
+ * and compares them against the provided FVK to verify the Orchard
+ * receiver belongs to this device.
+ *
+ * @next ZcashAddress
+ * @next Failure
+ */
+message ZcashDisplayAddress {
+    repeated uint32 address_n = 1;          // ZIP-32 derivation path [32', 133', account']
+    optional uint32 account = 2;            // Account index (alternative to full path)
+    optional string address = 3;            // Unified address string (u1...)
+    optional bytes ak = 4;                  // 32-byte authorizing key for verification
+    optional bytes nk = 5;                  // 32-byte nullifier deriving key for verification
+    optional bytes rivk = 6;               // 32-byte commitment randomness key for verification
+}
+
+/**
+ * Response: Verified Zcash address.
+ *
+ * @prev ZcashDisplayAddress
+ */
+message ZcashAddress {
+    optional string address = 1;            // Verified unified address string
+}

--- a/messages.proto
+++ b/messages.proto
@@ -216,6 +216,8 @@ enum MessageType {
   MessageType_ZcashOrchardFVK = 1305 [ (wire_out) = true ];
   MessageType_ZcashTransparentInput = 1306 [ (wire_in) = true ];
   MessageType_ZcashTransparentSig = 1307 [ (wire_out) = true ];
+  MessageType_ZcashDisplayAddress = 1308 [ (wire_in) = true ];
+  MessageType_ZcashAddress = 1309 [ (wire_out) = true ];
 
   // TRON
   MessageType_TronGetAddress = 1400 [ (wire_in) = true ];


### PR DESCRIPTION
## Summary
- Adds `ZcashDisplayAddress` (1308) and `ZcashAddress` (1309) message types for on-device unified address verification
- Host sends unified address string + FVK components (ak, nk, rivk); device re-derives Orchard keys from seed and verifies the receiver belongs to this device before displaying
- Includes nanopb options for all new fields (address max 256 bytes, keys 32 bytes each)

## Context
PR #100 landed the full 7.14.0 protocol batch (Solana, TRON, TON, Zcash Orchard PCZT, EVM metadata, BIP-85). This PR adds the one remaining Zcash feature: address display/verification, which was deferred from that batch.

## Files Changed
- `messages-zcash.proto` — 2 new messages (ZcashDisplayAddress, ZcashAddress)
- `messages.proto` — 2 new MessageType enum entries (1308, 1309)
- `messages-zcash.options` — nanopb size constraints for new fields

## Test Plan
- [ ] Proto compiles with `protoc` and `nanopb`
- [ ] Firmware integration on `feat/zcash-display-address` branch uses these messages
- [ ] Python-keepkey tests verify address derivation and display