### PR TITLE
feat(thorchain): add denom field to ThorchainMsgSend (field 11)

### DIFF
--- a/messages-thorchain.proto
+++ b/messages-thorchain.proto
@@ -60,6 +60,7 @@ message ThorchainMsgSend {
     optional uint64 amount = 8 [jstype = JS_STRING];
     optional OutputAddressType address_type = 9;
     reserved 10;
+    optional string denom = 11;         // asset denom, e.g. "rune" or IBC denom
 }
 
 message ThorchainMsgDeposit {


### PR DESCRIPTION
## What
Adds `optional string denom = 11;` to `ThorchainMsgSend`.

```diff
 message ThorchainMsgSend {
     optional uint64 amount = 8 [jstype = JS_STRING];
     optional OutputAddressType address_type = 9;
     reserved 10;
+    optional string denom = 11;         // asset denom, e.g. "rune" or IBC denom
 }
```

## Why
THORChain `MsgSend` now carries non-RUNE native assets — TCY, RUJIRA (RUJI),
and IBC-denominated tokens. The device needs the asset denom to display and
sign these correctly; today `ThorchainMsgSend` can only express RUNE.

## Wire compatibility
- New **optional** field, tag **11** — additive, backward compatible.
- Does not touch `reserved 10`.
- Clients that omit `denom` are unaffected (RUNE-only behavior preserved).

## Downstream
Consumed by keepkey-firmware (denom charset validation + display) and
python-keepkey test vectors, both staged to pin this commit once merged.
