### PR TITLE
feat(ripple): add memo field to RippleSignTx for THORChain swap routing

### DIFF
--- a/messages-ripple.proto
+++ b/messages-ripple.proto
@@ -34,6 +34,7 @@ message RippleSignTx {
 	optional uint32 sequence = 4;				// transaction sequence number
 	optional uint32 last_ledger_sequence = 5;	// see https://developers.ripple.com/reliable-transaction-submission.html#lastledgersequence
 	optional RipplePayment payment = 6;			// Payment transaction type
+	optional string memo = 7;					// transaction memo (e.g. THORChain swap routing memo)
 }
 
 /**


### PR DESCRIPTION
## What
Adds `optional string memo = 7;` to `RippleSignTx`.

```diff
 message RippleSignTx {
     optional RipplePayment payment = 6;			// Payment transaction type
+    optional string memo = 7;					// transaction memo (e.g. THORChain swap routing memo)
 }
```

## Why
XRP is a supported THORChain swap asset. THORChain routes swaps via a memo
string on the transaction; without a memo field the device cannot sign
XRP→THORChain swaps. This lets the host supply the routing memo for the device
to display and sign.

## Wire compatibility
- New **optional** field, tag **7** — additive, backward compatible.
- Existing XRP payment signing is unchanged when `memo` is omitted.

## Downstream
Consumed by keepkey-firmware (memo display) and python-keepkey; staged to pin
once merged.
