### PR TITLE
feat(zcash): add Ironwood signing metadata

### DIFF
--- a/messages-zcash.options
+++ b/messages-zcash.options
@@ -5,6 +5,7 @@ ZcashSignPCZT.transparent_digest max_size:32
 ZcashSignPCZT.sapling_digest max_size:32
 ZcashSignPCZT.orchard_digest max_size:32
 ZcashSignPCZT.orchard_anchor max_size:32
+ZcashSignPCZT.ironwood_digest max_size:32
 ZcashSignPCZT.expected_seed_fingerprint max_size:32
 
 ZcashPCZTAction.alpha max_size:32

--- a/messages-zcash.proto
+++ b/messages-zcash.proto
@@ -7,6 +7,11 @@
 
 syntax = "proto2";
 
+enum ZcashShieldedPool {
+    ZCASH_SHIELDED_POOL_ORCHARD = 0;
+    ZCASH_SHIELDED_POOL_IRONWOOD = 1;
+}
+
 // Sugar for easier handling in Java
 option java_package = "com.keepkey.deviceprotocol";
 option java_outer_classname = "KeepKeyMessageZcash";
@@ -45,6 +50,11 @@ message ZcashSignPCZT {
     optional uint32 version_group_id = 16;      // Version group ID
     optional uint32 lock_time = 17;             // Transaction lock time
     optional uint32 expiry_height = 18;         // Transaction expiry height
+    // NU6.3 / transaction-v6 Orchard-family pool selection. The existing
+    // orchard_* metadata fields describe the selected action bundle for wire
+    // compatibility; ironwood_digest is the fifth v6 transaction component.
+    optional ZcashShieldedPool shielded_pool = 19 [default = ZCASH_SHIELDED_POOL_ORCHARD];
+    optional bytes ironwood_digest = 20;        // 32-byte Ironwood component digest (v6)
     // Phase 3: transparent shielding support
     optional uint32 n_transparent_outputs = 29; // 0 for shielded-only (default)
     optional uint32 n_transparent_inputs = 30;  // 0 for shielded-only (default), >0 for hybrid shielding tx


### PR DESCRIPTION
## Why

NU6.3 activates transaction v6 and the Ironwood pool. Hosts must tell firmware which Orchard-family pool is being signed and provide the fifth ZIP-229 component digest.

## What changed

- add the Orchard/Ironwood shielded-pool enum
- add `shielded_pool` and `ironwood_digest` to `ZcashSignPCZT`
- constrain the new digest to 32 bytes in nanopb generation

The new tags are additive (`19` and `20`); existing v5 Orchard messages remain wire-compatible.

## Validation

- consumed by the firmware RC22 branch
- full firmware release image builds successfully
- firmware emulator: 388/388 tests pass
