### PR TITLE
feat(solana): add verified token recipient owner hints

### DIFF
--- a/messages-solana.options
+++ b/messages-solana.options
@@ -6,6 +6,8 @@ SolanaSignTx.raw_tx max_size:1232
 SolanaSignTx.token_info max_count:4
 SolanaSignTx.schema_payload max_size:256
 SolanaSignTx.schema_signature max_size:64
+SolanaSignTx.token_recipient_owner max_count:4
+SolanaSignTx.token_recipient_owner max_size:32
 SolanaTokenInfo.mint max_size:32
 SolanaTokenInfo.symbol max_size:13
 SolanaAddress.address max_size:45

--- a/messages-solana.proto
+++ b/messages-solana.proto
@@ -78,6 +78,15 @@ message SolanaSignTx {
     optional bytes schema_payload = 9;
     optional bytes schema_signature = 10;       // 64-byte compact secp256k1 over SHA256(payload)
     optional uint32 schema_signer_key_id = 11;  // trusted clearsign signer slot (0-3)
+    /*
+     * Candidate owners for SPL associated-token-account destinations. For a
+     * TransferChecked instruction, firmware may display an owner only after
+     * independently deriving ATA(owner, token_program, mint) and matching it
+     * to the signed destination account. An unmatched candidate is never
+     * treated as a recipient. This lets payment protocols such as x402 show
+     * their payTo address without trusting host-side decoding or chain RPC.
+     */
+    repeated bytes token_recipient_owner = 12;  // 32-byte Solana public keys (max 4)
 }
 
 /**


### PR DESCRIPTION
## Purpose

Add an optional SolanaSignTx field for candidate SPL token recipient owners. Firmware must derive ATA(owner, token_program, mint) and match the signed destination before displaying an owner.

This is the additive protocol prerequisite for hardware-verifiable zero-LUT Solana v0 payments such as x402. It does not enable blind signing and does not trust host-decoded payTo data.

## Wire change

- repeated bytes token_recipient_owner = 12
- max 4 entries, exactly 32 bytes accepted by firmware
- tags 5-8 remain reserved; schema tags 9-11 are unchanged

## Validation

- protoc descriptor compilation passes locally
- generated JS exposes tokenRecipientOwnerList

## SOP

This protocol PR precedes Python, firmware-fork, hdwallet, and Vault staging. No upstream firmware PR or release is part of this change.