### PR TITLE
fix(build): generate bindings for git dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,11 @@ jobs:
       - name: Install JavaScript generator dependencies
         run: npm ci
 
-      - name: Generate JavaScript bindings
-        run: npm run build:js
+      - name: Verify install generated JavaScript bindings
+        run: |
+          test -s lib/messages_pb.js
+          test -s lib/messages-solana_pb.js
+          test -s lib/messages-zcash_pb.js
 
       - name: Compile protocol descriptors
         run: |

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:js": "mkdir -p ./lib && ./node_modules/.bin/grpc_tools_node_protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:./lib --ts_out=./lib types.proto messages.proto messages-ethereum.proto messages-eos.proto messages-nano.proto messages-cosmos.proto messages-binance.proto messages-ripple.proto messages-tendermint.proto messages-thorchain.proto messages-osmosis.proto messages-mayachain.proto messages-solana.proto messages-tron.proto messages-ton.proto messages-zcash.proto messages-hive.proto",
     "build:json": "pbjs --keep-case -t json ./types.proto ./messages.proto ./messages-ethereum.proto ./messages-eos.proto ./messages-nano.proto ./messages-cosmos.proto ./messages-binance.proto ./messages-ripple.proto ./messages-tendermint.proto ./messages-thorchain.proto ./messages-osmosis.proto ./messages-mayachain.proto ./messages-solana.proto ./messages-tron.proto ./messages-ton.proto ./messages-zcash.proto ./messages-hive.proto > ./lib/proto.json",
     "build:postprocess": "find ./lib -name \"*.js\" -exec sed -i '' -e \"s/var global = Function(\\'return this\\')();/var global = (function(){ return this }).call(null);/g\" {} \\;",
+    "prepare": "npm run build:js",
     "prepublishOnly": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## Summary

- generate JavaScript and TypeScript bindings during the package prepare lifecycle
- make exact Git-SHA dependencies consumable without a published fork package
- make Protocol CI assert that a normal npm install creates the required bindings

## Root cause

The staging SOP requires hdwallet to resolve the exact canonical device-protocol Git commit. A clean Yarn Git dependency install of the current staging SHA produced only lib/.keep because the repository had no prepare lifecycle. That made the Git pin unusable and forced consumers back to a separately published artifact.

## Validation

- fresh node:20-bookworm container: npm ci generated all bindings through prepare
- exact GitHub commit installed through Yarn in a scratch consumer
- installed messages, Solana, and Zcash bindings are present
- Ironwood fields 19/20 and boolean serialization round-trip from the installed Git dependency

No protobuf wire definitions change. No package publish is involved.
