### PR TITLE
feat(features): advertise Taproot signing support

### DIFF
--- a/messages.proto
+++ b/messages.proto
@@ -319,6 +319,11 @@ message Features {
   optional bool wipe_code_protection = 25;
   optional uint32 auto_lock_delay_ms =
       26; // Current auto lock delay (in milliseconds)
+  optional bool supports_taproot =
+      27; // Firmware can derive and spend P2TR (BIP-86 / BIP-340 / BIP-341).
+          // Lets a host detect taproot support directly instead of inferring
+          // it from a firmware version, which breaks whenever the feature is
+          // retargeted to a different release.
 }
 
 /**


### PR DESCRIPTION
Adds the supports_taproot capability bit to Features so hosts and python-keepkey gate BIP-86/P2TR behavior on an explicit device capability instead of a firmware-version guess.\n\nTarget is the existing upstream protocol staging branch; no npm publication.\n\nLocal preflight: protobuf descriptor compilation, Zcash contract check, npm clean install, and JavaScript binding build passed. Canonical PR CI remains the merge gate.