### PR TITLE
feat(reset): dice-entropy fields for on-device roll collection

### DIFF
--- a/messages.proto
+++ b/messages.proto
@@ -576,6 +576,9 @@ message ResetDevice {
       7; // Initialize without ever showing the recovery sentence.
   optional uint32 auto_lock_delay_ms = 8; // Screensaver Timeout
   optional uint32 u2f_counter = 9;        // U2F Counter
+  optional bool dice_entropy =
+      10; // collect dice rolls on the device and mix them into the internal
+          // entropy before it is displayed or committed
 }
 
 /**
@@ -986,6 +989,10 @@ message FirmwareUpload {
  */
 message DebugLinkDecision {
   required bool yes_no = 1; // true for "Confirm", false for "Cancel"
+  optional string input =
+      2; // synthetic keyboard input for on-device entry flows (e.g. dice
+         // rolls '1'-'6', 'u' for undo); kept short so the decoded struct
+         // fits the tiny-message buffer
 }
 
 /**
@@ -1020,6 +1027,9 @@ message DebugLinkState {
       12;                            // last auto completed recovery word
   optional bytes firmware_hash = 13; // hash of the application and meta header
   optional bytes storage_hash = 14;  // hash of storage
+  optional bytes dice_digest =
+      15; // SHA-256 of the ASCII dice-roll string collected during a
+          // dice_entropy ResetDevice workflow
 }
 
 /**

--- a/types.proto
+++ b/types.proto
@@ -134,6 +134,7 @@ enum ButtonRequestType {
 	ButtonRequest_RemoveWipeCode = 36;
 	ButtonRequest_ChangeWipeCode = 37;
 	ButtonRequest_CreateWipeCode = 38;
+	ButtonRequest_DiceRoll = 39;
 }
 
 /**


### PR DESCRIPTION
## What

Four additions for the on-device dice-entropy ResetDevice flow (firmware PR: BitHighlander/keepkey-firmware#341-to-be):

- `ResetDevice.dice_entropy = 10` — ask the device to collect dice rolls with the single button and mix them into the internal entropy before it is displayed or committed. Tag 10 is the next free tag in this fork lineage (9 = u2f_counter; no reserved markers, gap tags deliberately not reused — same rationale as `Features.supports_taproot`).
- `DebugLinkDecision.input = 2` — synthetic keyboard input for on-device entry flows in DEBUG_LINK builds ('1'-'6' rolls, 'u' undo). Kept short (firmware sizes it at 40 chars) so the decoded nanopb struct fits the 64-byte tiny-message buffer.
- `DebugLinkState.dice_digest = 15` — SHA-256 of the collected ASCII roll string, so tests can prove the device received exactly the injected rolls.
- `ButtonRequestType.ButtonRequest_DiceRoll = 39` — announces the entry screen to the host (38 was the last used value; the reserved 30 gap is untouched).

## Why device-side entry

Desktop-entered dice only defends while the device RNG contribution stays secret; against the compromised-host + weak-RNG combination the rolls must never touch the computer. Coldcard enters dice on the signer for the same reason.

Wire-verified end-to-end by the python-keepkey emulator test (keepkey/python-keepkey feat/dice-entropy): digest parity on 99 injected rolls with undo churn, and the post-mix internal entropy still reproducing the documented sha256(internal || external) mnemonic.