### PR TITLE
feat(protocol): report taproot support in Features

### DIFF
--- a/messages.proto
+++ b/messages.proto
@@ -293,6 +293,11 @@ message Features {
   optional bool wipe_code_protection = 25;
   optional uint32 auto_lock_delay_ms =
       26; // Current auto lock delay (in milliseconds)
+  optional bool supports_taproot =
+      27; // Firmware can derive and spend P2TR (BIP-86 / BIP-340 / BIP-341).
+          // Lets a host detect taproot support directly instead of inferring
+          // it from a firmware version, which breaks whenever the feature is
+          // retargeted to a different release.
 }
 
 /**


### PR DESCRIPTION
Adds a single field to `Features`:

```proto
optional bool supports_taproot = 27;
```

## Why

`keepkey-firmware` sets this in `fsm_msg_common.h` so a host can detect P2TR
capability directly instead of inferring it from a firmware version string,
which breaks whenever the feature is retargeted to a different release.

## Why this is separate from #112

#112 carries the same field, and this PR keeps **field number 27 and the exact
wording** so the two agree and do not conflict when #112 lands.

It is split out because #112 is the full 7.15 proto surface (hive, near, ripple,
solana, zcash — 3,071 lines). Pinning that into the 7.14.3 bitcoin-only release
branch pulls in structured EIP-712 and Solana LUT fields that have no `.options`
entries in that tree, so nanopb emits `pb_callback_t` for them and both the ARM
and emulator builds fail with:

```
pb_callback_t forbidden. missing .options entry?
```

7.14.3 needs `supports_taproot` and nothing else from this repo — no source file
on that branch references any other field #112 adds.

## Checks

- `protoc` parses `messages.proto` clean
- field 27 is unused on `master` (`Features` has 1-18, 21-26)
- no duplicate field numbers after the change
- additive only: 3 lines, no field renumbered or removed